### PR TITLE
例外ハンドリングを追加

### DIFF
--- a/src/main/java/com/task9/crudapi_project/ClientResponse.java
+++ b/src/main/java/com/task9/crudapi_project/ClientResponse.java
@@ -1,0 +1,49 @@
+package com.task9.crudapi_project;
+
+import com.task9.crudapi_project.entity.Client;
+
+public class ClientResponse {
+    private int id;
+    private String name;
+    private int age;
+    private String working;
+
+    public ClientResponse(Client client) {
+        this.id = client.getId();
+        this.name = client.getName();
+        this.age = client.getAge();
+        this.working = client.getWorking();
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public int getAge() {
+        return age;
+    }
+
+    public void setAge(int age) {
+        this.age = age;
+    }
+
+    public String getWorking() {
+        return working;
+    }
+
+    public void setWorking(String working) {
+        this.working = working;
+    }
+}

--- a/src/main/java/com/task9/crudapi_project/ResourceNotFoundException.java
+++ b/src/main/java/com/task9/crudapi_project/ResourceNotFoundException.java
@@ -1,0 +1,19 @@
+package com.task9.crudapi_project;
+
+public class ResourceNotFoundException extends RuntimeException {
+    public ResourceNotFoundException() {
+        super();
+    }
+
+    public ResourceNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+
+    public ResourceNotFoundException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/com/task9/crudapi_project/controller/ClientController.java
+++ b/src/main/java/com/task9/crudapi_project/controller/ClientController.java
@@ -1,11 +1,20 @@
 package com.task9.crudapi_project.controller;
 
+import com.task9.crudapi_project.ClientResponse;
+import com.task9.crudapi_project.ResourceNotFoundException;
 import com.task9.crudapi_project.entity.Client;
 import com.task9.crudapi_project.service.ClientService;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Map;
 
 @RestController
 public class ClientController {
@@ -16,9 +25,29 @@ public class ClientController {
         this.clientService = clientService;
     }
 
+
     @GetMapping("clients")
     public List<Client> clients() {
         List<Client> clients = clientService.findAll();
         return clients;
+    }
+
+    @GetMapping("clients/{id}")
+    public ClientResponse findById(@PathVariable("id") int id) {
+        Client client = clientService.findById(id);
+        return new ClientResponse(client);
+    }
+
+
+    @ExceptionHandler(value = ResourceNotFoundException.class)
+    public ResponseEntity<Map<String, String>> handleNoResourceFound(
+            ResourceNotFoundException e, HttpServletRequest request) {
+        Map<String, String> body = Map.of(
+                "timestamp", ZonedDateTime.now().toString(),
+                "status", String.valueOf(HttpStatus.NOT_FOUND.value()),
+                "error", HttpStatus.NOT_FOUND.getReasonPhrase(),
+                "message", e.getMessage(),
+                "path", request.getRequestURI());
+        return new ResponseEntity(body, HttpStatus.NOT_FOUND);
     }
 }

--- a/src/main/java/com/task9/crudapi_project/mapper/ClientMapper.java
+++ b/src/main/java/com/task9/crudapi_project/mapper/ClientMapper.java
@@ -5,9 +5,13 @@ import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Select;
 
 import java.util.List;
+import java.util.Optional;
 
 @Mapper
 public interface ClientMapper {
     @Select("SELECT * FROM clients")
     List<Client> findAll();
+
+    @Select("SELECT * FROM clients WHERE id = #{id}")
+    Optional<Client> findById(int id);
 }

--- a/src/main/java/com/task9/crudapi_project/service/ClientService.java
+++ b/src/main/java/com/task9/crudapi_project/service/ClientService.java
@@ -6,4 +6,6 @@ import java.util.List;
 
 public interface ClientService {
     List<Client> findAll();
+
+    Client findById(int id);
 }

--- a/src/main/java/com/task9/crudapi_project/service/ClientServiceImpl.java
+++ b/src/main/java/com/task9/crudapi_project/service/ClientServiceImpl.java
@@ -1,10 +1,12 @@
 package com.task9.crudapi_project.service;
 
+import com.task9.crudapi_project.ResourceNotFoundException;
 import com.task9.crudapi_project.mapper.ClientMapper;
 import com.task9.crudapi_project.entity.Client;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 public class ClientServiceImpl implements ClientService {
@@ -18,5 +20,15 @@ public class ClientServiceImpl implements ClientService {
     @Override
     public List<Client> findAll() {
         return clientMapper.findAll();
+    }
+
+    @Override
+    public Client findById(int id) {
+        Optional<Client> client = clientMapper.findById(id);
+        if (client.isPresent()) {
+            return client.get();
+        } else {
+            throw new ResourceNotFoundException("resource not found");
+        }
     }
 }

--- a/src/main/java/com/task9/crudapi_project/service/ClientServiceImpl.java
+++ b/src/main/java/com/task9/crudapi_project/service/ClientServiceImpl.java
@@ -25,10 +25,6 @@ public class ClientServiceImpl implements ClientService {
     @Override
     public Client findById(int id) {
         Optional<Client> client = clientMapper.findById(id);
-        if (client.isPresent()) {
-            return client.get();
-        } else {
-            throw new ResourceNotFoundException("resource not found");
-        }
+        return client.orElseThrow(() -> new ResourceNotFoundException("resource not found:" + id));
     }
 }


### PR DESCRIPTION
# 概要
第9回課題のCRUD処理のREST APIを実装しました。
具体的にはclient_listデータベースに対するREAD機能の実装をしています。
また、第10回授業動画を視聴したため、存在しないIDをリクエストした時の例外ハンドリングも実装してみました。


# 動作確認
* GET（全件取得）

```curl --location 'http://localhost:8080/clients```

![get](https://github.com/minori-oya/task9/assets/138114043/664c4baf-7c0c-44bd-9a94-0d6d5b14571a)

* GET{id}（特定のID情報を取得）

```curl --location 'http://localhost:8080/clients/2```

![id2](https://github.com/minori-oya/task9/assets/138114043/32fb3780-e08d-49af-bd13-b473980f043e)

* GET{id}（存在しないIDをリクエストした時の例外処理）

```curl --location 'http://localhost:8080/clients/99```

![id99](https://github.com/minori-oya/task9/assets/138114043/a3de3070-d07e-4f3e-a4ce-396cd2944858)

* MySQLのデータベース
<img width="404" alt="databases" src="https://github.com/minori-oya/task9/assets/138114043/9432e7c4-ea6e-43b8-a15a-4e1072850f7e">

* clientsテーブル
<img width="453" alt="client_list" src="https://github.com/minori-oya/task9/assets/138114043/7823f3d5-89df-4388-b7da-a9dd4991238d">

